### PR TITLE
Add item frame contents flag

### DIFF
--- a/src/main/java/me/ryanhamshire/GPFlags/FlagsDataStore.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/FlagsDataStore.java
@@ -389,6 +389,8 @@ public class FlagsDataStore {
 
         this.addDefault(defaults, Messages.EnabledAllowVillagerTrading, "Players can now trade with villagers in this claim.", null);
         this.addDefault(defaults, Messages.DisabledAllowVillagerTrading, "Players can no longer trade with villagers in this claim.", null);
+        this.addDefault(defaults, Messages.EnabledAllowItemFrameContents, "Players with container trust can now manage item frame contents in this claim.", null);
+        this.addDefault(defaults, Messages.DisabledAllowItemFrameContents, "Players with container trust can no longer manage item frame contents in this claim.", null);
 
         this.addDefault(defaults, Messages.EnabledRestoreGrazedGrass, "Grass will now immediiately regrow after being grazed by sheep.", null);
         this.addDefault(defaults, Messages.DisabledRestoreGrazedGrass, "Grass will no longer immediately regrow after being grazed by sheep.", null);

--- a/src/main/java/me/ryanhamshire/GPFlags/GPFlagsConfig.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/GPFlagsConfig.java
@@ -200,6 +200,7 @@ public class GPFlagsConfig {
             this.flagManager.registerFlagDefinition(new FlagDef_AllowWitherDamage(this.flagManager, plugin));
 
             this.flagManager.registerFlagDefinition(new FlagDef_AllowVillagerTrading(this.flagManager, plugin));
+            this.flagManager.registerFlagDefinition(new FlagDef_AllowItemFrameContents(this.flagManager, plugin));
             this.flagManager.registerFlagDefinition(new FlagDef_RestoreGrazedGrass(this.flagManager, plugin));
 
             try {

--- a/src/main/java/me/ryanhamshire/GPFlags/Messages.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/Messages.java
@@ -273,6 +273,8 @@ public enum Messages {
 
     EnabledAllowVillagerTrading,
     DisabledAllowVillagerTrading,
+    EnabledAllowItemFrameContents,
+    DisabledAllowItemFrameContents,
 
     EnabledRestoreGrazedGrass,
     DisabledRestoreGrazedGrass,

--- a/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_AllowItemFrameContents.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_AllowItemFrameContents.java
@@ -1,0 +1,96 @@
+package me.ryanhamshire.GPFlags.flags;
+
+import java.util.Arrays;
+import java.util.List;
+
+import me.ryanhamshire.GPFlags.Flag;
+import me.ryanhamshire.GPFlags.FlagManager;
+import me.ryanhamshire.GPFlags.GPFlags;
+import me.ryanhamshire.GPFlags.MessageSpecifier;
+import me.ryanhamshire.GPFlags.Messages;
+import me.ryanhamshire.GPFlags.util.Util;
+import me.ryanhamshire.GriefPrevention.Claim;
+import me.ryanhamshire.GriefPrevention.ClaimPermission;
+import me.ryanhamshire.GriefPrevention.GriefPrevention;
+import me.ryanhamshire.GriefPrevention.PlayerData;
+import me.ryanhamshire.GriefPrevention.events.ClaimPermissionCheckEvent;
+import org.bukkit.Material;
+import org.bukkit.entity.ItemFrame;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.inventory.ItemStack;
+
+public class FlagDef_AllowItemFrameContents extends FlagDefinition {
+
+    public FlagDef_AllowItemFrameContents(FlagManager manager, GPFlags plugin) {
+        super(manager, plugin);
+    }
+
+    @EventHandler
+    public void onItemFramePermissionCheck(ClaimPermissionCheckEvent event) {
+        if (event.getCheckedPlayer() == null) return;
+        if (event.getRequiredPermission() != ClaimPermission.Build) return;
+
+        Event triggeringEvent = event.getTriggeringEvent();
+
+        if (triggeringEvent instanceof PlayerInteractEntityEvent) {
+            PlayerInteractEntityEvent interactEvent = (PlayerInteractEntityEvent) triggeringEvent;
+            if (!(interactEvent.getRightClicked() instanceof ItemFrame)) return;
+
+            ItemFrame itemFrame = (ItemFrame) interactEvent.getRightClicked();
+            if (hasFlagAndContainerTrust(itemFrame, interactEvent.getPlayer())) {
+                event.setDenialReason(null);
+            }
+            return;
+        }
+
+        if (triggeringEvent instanceof EntityDamageByEntityEvent) {
+            EntityDamageByEntityEvent damageEvent = (EntityDamageByEntityEvent) triggeringEvent;
+            if (!(damageEvent.getEntity() instanceof ItemFrame)) return;
+            if (!(damageEvent.getDamager() instanceof Player)) return;
+
+            ItemFrame itemFrame = (ItemFrame) damageEvent.getEntity();
+            ItemStack item = itemFrame.getItem();
+            if (item == null || item.getType() == Material.AIR) return;
+
+            Player player = (Player) damageEvent.getDamager();
+            if (hasFlagAndContainerTrust(itemFrame, player)) {
+                event.setDenialReason(null);
+            }
+        }
+    }
+
+    private boolean hasFlagAndContainerTrust(ItemFrame itemFrame, Player player) {
+        Flag flag = this.getFlagInstanceAtLocation(itemFrame.getLocation(), player);
+        if (flag == null) return false;
+
+        PlayerData playerData = GriefPrevention.instance.dataStore.getPlayerData(player.getUniqueId());
+        Claim claim = GriefPrevention.instance.dataStore.getClaimAt(itemFrame.getLocation(), false, playerData.lastClaim);
+        if (claim == null) return false;
+
+        return Util.canInventory(claim, player);
+    }
+
+    @Override
+    public String getName() {
+        return "AllowItemFrameContents";
+    }
+
+    @Override
+    public MessageSpecifier getSetMessage(String parameters) {
+        return new MessageSpecifier(Messages.EnabledAllowItemFrameContents);
+    }
+
+    @Override
+    public MessageSpecifier getUnSetMessage() {
+        return new MessageSpecifier(Messages.DisabledAllowItemFrameContents);
+    }
+
+    @Override
+    public List<FlagType> getFlagType() {
+        return Arrays.asList(FlagType.CLAIM, FlagType.DEFAULT);
+    }
+}


### PR DESCRIPTION
This adds a new `AllowItemFrameContents` flag.

When this flag is set, players who already have container trust in the claim can add items to existing item frames, rotate them, and remove the item from the frame. This does not allow placing new item frames, and it does not allow breaking empty item frames. It essentially treats item frames as containers while enabled to allow players to play games that require placing or modiying map arts in frames such as chess while not giving full access to the claim.

This depends on the recent GP change that passes the original item frame right-click event through ClaimPermissionCheckEvent, so GPFlags can tell when the build check is actually for interacting with an existing item frame. Commit [9c68edb](https://github.com/GriefPrevention/GriefPrevention/commit/9c68edb63bcf728587e5c1660f71983ec326e04b)
