### PR TITLE
Allow GP "permissiontrust" to manage claim flags

### DIFF
--- a/src/main/java/me/ryanhamshire/GPFlags/FlagManager.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/FlagManager.java
@@ -36,6 +36,7 @@ public class FlagManager {
     private final List<String> worlds = new ArrayList<>();
 
     public static final String DEFAULT_FLAG_ID = "-2";
+    public static final String CLAIM_MANAGER_SET_FLAGS_FLAG = "AllowClaimManagersSetFlags";
 
     public FlagManager() {
         this.definitions = new ConcurrentHashMap<>();

--- a/src/main/java/me/ryanhamshire/GPFlags/FlagsDataStore.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/FlagsDataStore.java
@@ -391,6 +391,8 @@ public class FlagsDataStore {
         this.addDefault(defaults, Messages.DisabledAllowVillagerTrading, "Players can no longer trade with villagers in this claim.", null);
         this.addDefault(defaults, Messages.EnabledAllowItemFrameContents, "Players with container trust can now manage item frame contents in this claim.", null);
         this.addDefault(defaults, Messages.DisabledAllowItemFrameContents, "Players with container trust can no longer manage item frame contents in this claim.", null);
+        this.addDefault(defaults, Messages.EnabledAllowClaimManagersSetFlags, "Players with manage trust can now configure flags in this claim.", null);
+        this.addDefault(defaults, Messages.DisabledAllowClaimManagersSetFlags, "Players with manage trust can no longer configure flags in this claim.", null);
 
         this.addDefault(defaults, Messages.EnabledRestoreGrazedGrass, "Grass will now immediiately regrow after being grazed by sheep.", null);
         this.addDefault(defaults, Messages.DisabledRestoreGrazedGrass, "Grass will no longer immediately regrow after being grazed by sheep.", null);

--- a/src/main/java/me/ryanhamshire/GPFlags/GPFlagsConfig.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/GPFlagsConfig.java
@@ -201,6 +201,7 @@ public class GPFlagsConfig {
 
             this.flagManager.registerFlagDefinition(new FlagDef_AllowVillagerTrading(this.flagManager, plugin));
             this.flagManager.registerFlagDefinition(new FlagDef_AllowItemFrameContents(this.flagManager, plugin));
+            this.flagManager.registerFlagDefinition(new FlagDef_AllowClaimManagersSetFlags(this.flagManager, plugin));
             this.flagManager.registerFlagDefinition(new FlagDef_RestoreGrazedGrass(this.flagManager, plugin));
 
             try {

--- a/src/main/java/me/ryanhamshire/GPFlags/Messages.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/Messages.java
@@ -275,6 +275,8 @@ public enum Messages {
     DisabledAllowVillagerTrading,
     EnabledAllowItemFrameContents,
     DisabledAllowItemFrameContents,
+    EnabledAllowClaimManagersSetFlags,
+    DisabledAllowClaimManagersSetFlags,
 
     EnabledRestoreGrazedGrass,
     DisabledRestoreGrazedGrass,

--- a/src/main/java/me/ryanhamshire/GPFlags/commands/CommandSetClaimFlag.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/commands/CommandSetClaimFlag.java
@@ -65,7 +65,7 @@ public class CommandSetClaimFlag implements TabExecutor {
         }
 
         // Check that they can set flags in the area
-        if (!Util.canEdit(player, claim)) {
+        if (!Util.canConfigureClaimFlags(player, claim)) {
             MessagingUtil.sendMessage(player, TextMode.Err, Messages.NotYourClaim);
             return true;
         }

--- a/src/main/java/me/ryanhamshire/GPFlags/commands/CommandSetClaimFlag.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/commands/CommandSetClaimFlag.java
@@ -65,7 +65,7 @@ public class CommandSetClaimFlag implements TabExecutor {
         }
 
         // Check that they can set flags in the area
-        if (!Util.canConfigureClaimFlags(player, claim)) {
+        if (!Util.canEdit(player, claim)) {
             MessagingUtil.sendMessage(player, TextMode.Err, Messages.NotYourClaim);
             return true;
         }

--- a/src/main/java/me/ryanhamshire/GPFlags/commands/CommandSetClaimFlag.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/commands/CommandSetClaimFlag.java
@@ -65,7 +65,7 @@ public class CommandSetClaimFlag implements TabExecutor {
         }
 
         // Check that they can set flags in the area
-        if (!Util.canEdit(player, claim)) {
+        if (!Util.canConfigureClaimFlags(player, claim, def)) {
             MessagingUtil.sendMessage(player, TextMode.Err, Messages.NotYourClaim);
             return true;
         }

--- a/src/main/java/me/ryanhamshire/GPFlags/commands/CommandUnsetClaimFlag.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/commands/CommandUnsetClaimFlag.java
@@ -57,7 +57,7 @@ public class CommandUnsetClaimFlag implements TabExecutor {
             return true;
         }
 
-        if (!Util.canConfigureClaimFlags(player, claim)) {
+        if (!Util.canEdit(player, claim)) {
             MessagingUtil.sendMessage(player, TextMode.Err, Messages.NotYourClaim);
             return true;
         }

--- a/src/main/java/me/ryanhamshire/GPFlags/commands/CommandUnsetClaimFlag.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/commands/CommandUnsetClaimFlag.java
@@ -57,7 +57,7 @@ public class CommandUnsetClaimFlag implements TabExecutor {
             return true;
         }
 
-        if (!Util.canEdit(player, claim)) {
+        if (!Util.canConfigureClaimFlags(player, claim)) {
             MessagingUtil.sendMessage(player, TextMode.Err, Messages.NotYourClaim);
             return true;
         }

--- a/src/main/java/me/ryanhamshire/GPFlags/commands/CommandUnsetClaimFlag.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/commands/CommandUnsetClaimFlag.java
@@ -57,7 +57,7 @@ public class CommandUnsetClaimFlag implements TabExecutor {
             return true;
         }
 
-        if (!Util.canEdit(player, claim)) {
+        if (!Util.canConfigureClaimFlags(player, claim, def)) {
             MessagingUtil.sendMessage(player, TextMode.Err, Messages.NotYourClaim);
             return true;
         }

--- a/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_AllowClaimManagersSetFlags.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_AllowClaimManagersSetFlags.java
@@ -1,0 +1,36 @@
+package me.ryanhamshire.GPFlags.flags;
+
+import me.ryanhamshire.GPFlags.FlagManager;
+import me.ryanhamshire.GPFlags.GPFlags;
+import me.ryanhamshire.GPFlags.MessageSpecifier;
+import me.ryanhamshire.GPFlags.Messages;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class FlagDef_AllowClaimManagersSetFlags extends FlagDefinition {
+
+    public FlagDef_AllowClaimManagersSetFlags(FlagManager manager, GPFlags plugin) {
+        super(manager, plugin);
+    }
+
+    @Override
+    public String getName() {
+        return FlagManager.CLAIM_MANAGER_SET_FLAGS_FLAG;
+    }
+
+    @Override
+    public MessageSpecifier getSetMessage(String parameters) {
+        return new MessageSpecifier(Messages.EnabledAllowClaimManagersSetFlags);
+    }
+
+    @Override
+    public MessageSpecifier getUnSetMessage() {
+        return new MessageSpecifier(Messages.DisabledAllowClaimManagersSetFlags);
+    }
+
+    @Override
+    public List<FlagType> getFlagType() {
+        return Arrays.asList(FlagType.CLAIM, FlagType.DEFAULT);
+    }
+}

--- a/src/main/java/me/ryanhamshire/GPFlags/util/Util.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/util/Util.java
@@ -80,6 +80,11 @@ public class Util {
         }
     }
 
+    public static boolean canConfigureClaimFlags(Player player, Claim claim) {
+        if (claim == null) return false;
+        return canEdit(player, claim) || canManage(claim, player);
+    }
+
     public static List<String> flagTab(CommandSender sender, String arg) {
         List<String> flags = new ArrayList<>();
         GPFlags.getInstance().getFlagManager().getFlagDefinitions().forEach(flagDefinition -> {

--- a/src/main/java/me/ryanhamshire/GPFlags/util/Util.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/util/Util.java
@@ -80,6 +80,22 @@ public class Util {
         }
     }
 
+    public static boolean canConfigureClaimFlags(Player player, Claim claim, FlagDefinition def) {
+        if (claim == null) return false;
+        if (canEdit(player, claim)) return true;
+        if (!canManage(claim, player)) return false;
+        if (def.getName().equalsIgnoreCase(FlagManager.CLAIM_MANAGER_SET_FLAGS_FLAG)) return false;
+        return allowsClaimManagersToSetFlags(claim);
+    }
+
+    public static boolean allowsClaimManagersToSetFlags(Claim claim) {
+        if (claim == null) return false;
+        Location location = claim.getLesserBoundaryCorner();
+        if (location == null || location.getWorld() == null) return false;
+        return GPFlags.getInstance().getFlagManager().getEffectiveFlag(
+                FlagManager.CLAIM_MANAGER_SET_FLAGS_FLAG, claim, location.getWorld()) != null;
+    }
+
     public static List<String> flagTab(CommandSender sender, String arg) {
         List<String> flags = new ArrayList<>();
         GPFlags.getInstance().getFlagManager().getFlagDefinitions().forEach(flagDefinition -> {

--- a/src/main/java/me/ryanhamshire/GPFlags/util/Util.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/util/Util.java
@@ -80,11 +80,6 @@ public class Util {
         }
     }
 
-    public static boolean canConfigureClaimFlags(Player player, Claim claim) {
-        if (claim == null) return false;
-        return canEdit(player, claim) || canManage(claim, player);
-    }
-
     public static List<String> flagTab(CommandSender sender, String arg) {
         List<String> flags = new ArrayList<>();
         GPFlags.getInstance().getFlagManager().getFlagDefinitions().forEach(flagDefinition -> {


### PR DESCRIPTION
This allows players who have `/permissiontrust` on a claim to be able to set and unset claim flags. The trusted players are still required to have the GPFlags permissions as they would normally require within their own claims.

GPs PermissionTrust is the trust level that allows for managing a claim and trusting other players within that claim. I think it makes sence for those players to also be able to set and unset claim flags. 

Previously claim flags could only be configured by claim owner because `/setclaimflag` and `/unsetclaimflag` required `ClaimPermission.Edit`. This changes the claim flag authorization check to also allow `ClaimPermission.Manage` which  is GPs `/permissiontrust`