### PR TITLE
Feature Request: SpawnReason.COMMAND bypasses anti-spawn flags

### DIFF
--- a/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_NoMobSpawns.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_NoMobSpawns.java
@@ -21,6 +21,7 @@ public class FlagDef_NoMobSpawns extends FlagDefinition {
 
         SpawnReason reason = event.getSpawnReason();
         if (reason == SpawnReason.SLIME_SPLIT) return;
+        if (reason == SpawnReason.COMMAND) return;
         WorldSettings settings = this.settingsManager.get(event.getEntity().getWorld());
         if (settings.noMonsterSpawnIgnoreSpawners && Util.isSpawnerReason(reason)) return;
 

--- a/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_NoMobSpawnsType.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_NoMobSpawnsType.java
@@ -40,6 +40,7 @@ public class FlagDef_NoMobSpawnsType extends FlagDefinition {
         if (isNotAllowed(type, flag)) {
             CreatureSpawnEvent.SpawnReason reason = event.getSpawnReason();
             if (reason == CreatureSpawnEvent.SpawnReason.SLIME_SPLIT) return;
+            if (reason == CreatureSpawnEvent.SpawnReason.COMMAND) return;
             if (reason == CreatureSpawnEvent.SpawnReason.SPAWNER || reason == CreatureSpawnEvent.SpawnReason.SPAWNER_EGG) {
                 event.getEntity().setMetadata(this.ALLOW_TARGET_TAG, new FixedMetadataValue(GPFlags.getInstance(), Boolean.TRUE));
                 return;

--- a/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_NoMonsterSpawns.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_NoMonsterSpawns.java
@@ -29,6 +29,7 @@ public class FlagDef_NoMonsterSpawns extends FlagDefinition {
 
         SpawnReason reason = event.getSpawnReason();
         if (reason == SpawnReason.SLIME_SPLIT) return;
+        if (reason == SpawnReason.COMMAND) return;
 
         WorldSettings settings = this.settingsManager.get(event.getEntity().getWorld());
         if (settings.noMonsterSpawnIgnoreSpawners && Util.isSpawnerReason(reason)) return;


### PR DESCRIPTION
Specifically the NoMobSpawns, NoMobSpawnsType, and NoMonsterSpawns flags.

I feel this is necessary as I have a plugin that spawns in villager-traders into my spawn-area with `SpawnReason.COMMAND`, however the `NoMobSpawns` flag blocks all spawns unless they had `SLIME_SPLIT` or `SPAWNER` as a SpawnReason.

I feel that `COMMAND` should also exempt mobs from a spawn-event cancellation since `SpawnReason.COMMAND` is pretty intentional and should only ever be occurring because of a plugin or admin doing something, not by regular vanilla spawn mechanics.